### PR TITLE
fix(hook/zsh): Check if `TMUX` server is available before updating the context switching option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,15 @@ The plugin supports the following `global` configuration options:
 | `@tmux_kubenv_color_context_bg`   | The _background color_ of the _context_ section   | `#00DCEE`    |
 | `@tmux_kubenv_color_namespace_fg` | The _foreground color_ of the _namespace_ section | `#124F76`    |
 | `@tmux_kubenv_color_namespace_bg` | The _background color_ of the _namespace_ section | `#D69F00`    |
+
+## Utilities
+
+Helper utilities supporting the plugin functionality.
+
+### `tmux_kubenv_precmd_hook` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function
+
+A [ZSH](https://www.zsh.org) `precmd` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function that automatically updates the plugin context based on the current `KUBECONFIG` in use.
+To allow configurable _enable_/_disable_ capability to the hook, two additional functions are provided:
+
+- `tmux_kubenv_precmd_hook_enable` - __adds__ the `hook` to the `precmd_functions` list
+- `tmux_kubenv_precmd_hook_disable` - __removes__ the `hook` from the `precmd_functions` list

--- a/scripts/hook_zsh.sh
+++ b/scripts/hook_zsh.sh
@@ -4,7 +4,9 @@ OPTION_KUBECONFIG="@tmux_kubenv_kubeconfig"
 
 tmux_kubenv_precmd_hook() {
 	# Update option with the current KUBECONFIG value
-	tmux set-option -gp "$OPTION_KUBECONFIG" "$KUBECONFIG"
+	if tmux info &> /dev/null; then
+		tmux set-option -gp "$OPTION_KUBECONFIG" "$KUBECONFIG"
+	fi
 }
 
 tmux_kubenv_precmd_hook_enable() {


### PR DESCRIPTION
### What is the purpose of the PR ?

This PR fixes an issue with the `precmd` hook that tries to update the _context-switching_ `TMUX` option regardless of the server availability, causing the following message on each terminal prompt 

```sh
no server running on /tmp/tmux-1000/default
```

In addition, a new `utilities` section is added to the `README.md` to list the supporting tools used by the plugin.

### What issue(s) does the PR address ?

Fixes: https://github.com/vitanovs/tmux-kubenv/issues/7