### PR TITLE
feat(kubenv): Set `default` namespace value when not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,3 @@ The plugin supports the following `global` configuration options:
 | `@tmux_kubenv_color_context_bg`   | The _background color_ of the _context_ section   | `#00DCEE`    |
 | `@tmux_kubenv_color_namespace_fg` | The _foreground color_ of the _namespace_ section | `#124F76`    |
 | `@tmux_kubenv_color_namespace_bg` | The _background color_ of the _namespace_ section | `#D69F00`    |
-
-## Utilities
-
-Helper utilities supporting the plugin functionality.
-
-### `tmux_kubenv_precmd_hook` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function
-
-A [ZSH](https://www.zsh.org) `precmd` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function that automatically updates the plugin context based on the current `KUBECONFIG` in use.
-To allow configurable _enable_/_disable_ capability to the hook, two additional functions are provided:
-
-- `tmux_kubenv_precmd_hook_enable` - __adds__ the `hook` to the `precmd_functions` list
-- `tmux_kubenv_precmd_hook_disable` - __removes__ the `hook` from the `precmd_functions` list

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,11 @@
+# Utilities
+
+Helper utilities supporting the plugin functionality.
+
+## `tmux_kubenv_precmd_hook` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function
+
+A [ZSH](https://www.zsh.org) `precmd` [hook](https://zsh.sourceforge.io/Doc/Release/Functions.html#Hook-Functions) function that automatically updates the plugin context based on the current `KUBECONFIG` in use.
+To allow configurable _enable_/_disable_ capability to the hook, two additional functions are provided:
+
+- `tmux_kubenv_precmd_hook_enable` - __adds__ the `hook` to the `precmd_functions` list
+- `tmux_kubenv_precmd_hook_disable` - __removes__ the `hook` from the `precmd_functions` list

--- a/kubenv.tmux
+++ b/kubenv.tmux
@@ -132,7 +132,10 @@ tmux_kubenv_get_kubeconfig_namespace() {
 	fi
 
 	local namespace=$(kubectl --kubeconfig="$kubeconfig" config view -o jsonpath='{..contexts[?(@.name == "'$context'")].context.namespace}')
-	if [ -z "$namespace" ]; then
+	if [ -z "$namespace" -a -n "$context" ]; then
+		echo "default"
+		return 1
+	elif [ -z "$namespace" -a -z "$contexts" ]; then
 		echo $TMUX_KUBENV_PROMPT_NO_CONTENT
 		return 1
 	fi


### PR DESCRIPTION
### What is the purpose of the PR ?

This PR features a change that updates the `prompt` behaviour to set `default` value for `namespace` during
initialisation or when the `namespace` is not set.

### What issue(s) does the PR address ?

Fixes: https://github.com/vitanovs/tmux-kubenv/issues/6

### What additional changes are included ?

- Move `utilities` section from `README.md` to a dedicated page under `/docs`.